### PR TITLE
fix formatting issue in Tampa explanation panels

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -884,7 +884,7 @@
       var containerElement = document.createElement(containerTag);
       for (var stringContent of stringContentArray) {
         var listItem = document.createElement(listItemTag);
-        listItem.innerText = stringContent;
+        listItem.innerHTML = stringContent;
         containerElement.appendChild(listItem);
       }
       return containerElement;


### PR DESCRIPTION
While reviewing ActivityViz feedback I noticed a problem with the text in the explanation panels. We were trying to configure the text with HTML, but the software was only configured to look at text. The result was the raw HTML was printed to the screen.

Before:
![image](https://user-images.githubusercontent.com/19381192/79009771-2dbb4a00-7b15-11ea-8eb8-eeff153f7dd6.png)

After:
![image](https://user-images.githubusercontent.com/19381192/79009859-60fdd900-7b15-11ea-9545-ebdc7c7504d5.png)
